### PR TITLE
Upgrade to TypeScript 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/express-session": "^0.0.32",
     "@types/graphql": "^0.9.3",
     "@types/helmet": "^0.0.34",
-    "@types/isomorphic-fetch": "^0.0.33",
+    "@types/isomorphic-fetch": "^0.0.34",
     "@types/jest": "^19.2.2",
     "@types/marked": "^0.0.28",
     "@types/moment": "^2.13.0",
@@ -106,7 +106,7 @@
     "supertest-session": "^3.0.0",
     "ts-jest": "^19.0.8",
     "tslint": "^5.4.3",
-    "typescript": "^2.2.2",
+    "typescript": "2.3.4",
     "webpack-combine-loaders": "^2.0.3",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,9 +96,9 @@
   dependencies:
     "@types/express" "*"
 
-"@types/isomorphic-fetch@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.33.tgz#3ea1b86f8b73e6a7430d01d4dbd5b1f63fd72718"
+"@types/isomorphic-fetch@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz#3c3483e606c041378438e951464f00e4e60706d6"
 
 "@types/jest@^19.2.2":
   version "19.2.2"
@@ -6723,9 +6723,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
+typescript@2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 typo-js@*:
   version "1.0.3"


### PR DESCRIPTION
Only change necessary to make this work is an upgrade to the isomorphic-fetch types.

Incremental progress. The upgrade to TypeScript 2.4 is much more difficult it seems.